### PR TITLE
Content reader protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-...
+This release contains a minor change to the way blocks store their internal
+content reference. While this is an implementation detail, it has the potential
+to break some third-party block stores if they happened to rely on it.
+
+### Added
+- Predicate `blocks.core/loaded?` which is the complement of `lazy?`.
+- `blocks.data/ContentReader` protocol for richer byte source integration.
+
+### Changed
+- *BREAKING:* blocks no longer have a separate `reader` field - the `content`
+  field either stores a `PersistentBytes` object (as before) _or_ a content
+  reader.
+- Dependencies upgraded.
 
 ## [1.1.0] - 2017-12-24
 

--- a/project.clj
+++ b/project.clj
@@ -53,7 +53,7 @@
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog"]}
 
    :coverage
-   {:plugins [[lein-cloverage "1.0.11"]]
+   {:plugins [[lein-cloverage "1.0.10"]]
     :dependencies [[commons-logging "1.2"]
                    [riddley "0.1.15"]]
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject mvxcvi/blocks "1.1.1-SNAPSHOT"
+(defproject mvxcvi/blocks "1.2.0-SNAPSHOT"
   :description "Content-addressed data storage interface."
   :url "https://github.com/greglook/blocks"
   :license {:name "Public Domain"
@@ -53,7 +53,7 @@
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog"]}
 
    :coverage
-   {:plugins [[lein-cloverage "1.0.10"]]
+   {:plugins [[lein-cloverage "1.0.11"]]
     :dependencies [[commons-logging "1.2"]
                    [riddley "0.1.15"]]
     :jvm-opts ["-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog"

--- a/src/blocks/core.clj
+++ b/src/blocks/core.clj
@@ -26,7 +26,9 @@
     (blocks.data
       Block
       PersistentBytes)
-    java.io.File
+    (java.io
+      File
+      FileInputStream)
     multihash.core.Multihash
     org.apache.commons.io.input.CountingInputStream))
 
@@ -74,7 +76,7 @@
   ([file algorithm]
    (let [file (io/file file)
          hash-fn (data/checked-hasher algorithm)
-         reader #(io/input-stream file)
+         reader (fn file-reader [] (FileInputStream. file))
          id (hash-fn (reader))]
      (data/lazy-block id (.length file) reader))))
 

--- a/src/blocks/core.clj
+++ b/src/blocks/core.clj
@@ -57,13 +57,13 @@
 (defn loaded?
   "True if the block's content is already loaded into memory."
   [block]
-  (data/loaded? block))
+  (data/byte-content? block))
 
 
 (defn lazy?
   "True if the given block reads its content on-demand."
   [block]
-  (not (data/loaded? block)))
+  (not (data/byte-content? block)))
 
 
 (defn from-file

--- a/src/blocks/core.clj
+++ b/src/blocks/core.clj
@@ -54,11 +54,16 @@
 
 ;; ## Block IO
 
+(defn loaded?
+  "True if the block's content is already loaded into memory."
+  [block]
+  (data/loaded? block))
+
+
 (defn lazy?
-  "Returns true if the given block loads its content lazily. Returns false if
-  all of the block's content is loaded in memory."
-  [^Block block]
-  (not (instance? PersistentBytes (.content block))))
+  "True if the given block reads its content on-demand."
+  [block]
+  (not (data/loaded? block)))
 
 
 (defn from-file

--- a/src/blocks/core.clj
+++ b/src/blocks/core.clj
@@ -124,16 +124,11 @@
 
   The returned block will have the same extra attributes and metadata as the one
   given."
-  [^Block block]
+  [block]
   (if (lazy? block)
-    (let [content (with-open [stream (open block)]
-                    (bytes/to-byte-array stream))]
-      (Block. (:id block)
-              (count content)
-              (PersistentBytes/wrap content)
-              (._attrs block)
-              (meta block)))
-    ; Block is already loaded.
+    (-> (data/load-block (:id block) (open block))
+        (into (remove (comp #{:id :size} key)) block)
+        (with-meta (meta block)))
     block))
 
 

--- a/src/blocks/core.clj
+++ b/src/blocks/core.clj
@@ -58,7 +58,7 @@
   "Returns true if the given block loads its content lazily. Returns false if
   all of the block's content is loaded in memory."
   [^Block block]
-  (nil? (.content block)))
+  (not (instance? PersistentBytes (.content block))))
 
 
 (defn from-file
@@ -126,7 +126,6 @@
       (Block. (:id block)
               (count content)
               (PersistentBytes/wrap content)
-              nil
               (._attrs block)
               (meta block)))
     ; Block is already loaded.

--- a/src/blocks/data.clj
+++ b/src/blocks/data.clj
@@ -208,7 +208,7 @@
     (bounded-input-stream (.open this) start end))
 
 
-  clojure.lang.IFn
+  clojure.lang.Fn
 
   (read-all
     [this]

--- a/src/blocks/data.clj
+++ b/src/blocks/data.clj
@@ -6,14 +6,14 @@
   number of bytes in the block content.
 
   Internally, blocks either have their content in-memory as persistent bytes,
-  or a _source_ which constructs new input streams for the block data on
+  or a _reader_ which constructs new input streams for the block data on
   demand. A block with in-memory content is considered a _loaded block_, while
-  blocks with other sources are _lazy blocks_.
+  blocks with readers are _lazy blocks_.
 
   A block's id, size, and content cannot be changed after construction, so
-  clients can be relatively certain that the block's id is valid. Blocks _may_
-  have additional attributes associated with them and support metadata, similar
-  to records."
+  clients can be confident that the block's id is valid. Blocks _may_ have
+  additional attributes associated with them and support metadata, similar to
+  records."
   (:require
     [byte-streams :as bytes]
     [multihash.core :as multihash]
@@ -241,8 +241,8 @@
 
 ;; ## Utility Functions
 
-(defn loaded?
-  "True if the block has content loaded into memory."
+(defn byte-content?
+  "True if the block has content loaded into memory as persistent bytes."
   [^Block block]
   (persistent-bytes? (.content block)))
 
@@ -305,9 +305,9 @@
 
 
 (defn lazy-block
-  "Creates a block from a content source. The simplest version is a no-arg
-  function which should return a new `InputStream` to read the block contents.
-  The block is given the id and size directly, without being checked."
+  "Creates a block from a content reader. The simplest version is a no-arg
+  function which should return a new `InputStream` to read the full block
+  content. The block is given the id and size directly, without being checked."
   ^blocks.data.Block
   [id size reader]
   (->Block id size reader nil nil))
@@ -331,7 +331,11 @@
   (let [hash-fn (checked-hasher algorithm)
         content (collect-bytes source)]
     (when (pos? (count content))
-      (->Block (hash-fn (read-all content)) (count content) content nil nil))))
+      (->Block (hash-fn (read-all content))
+               (count content)
+               content
+               nil
+               nil))))
 
 
 (defn clean-block

--- a/src/blocks/data.clj
+++ b/src/blocks/data.clj
@@ -5,15 +5,15 @@
   is a `Multihash` with the digest identifying the content. The size is the
   number of bytes in the block content.
 
-  Internally, blocks either have in-memory content holding the data, or a
-  reader function which returns new input streams for the block data. A block
-  with in-memory content is a _loaded block_, while a block with a reader
-  function is a _lazy block_.
+  Internally, blocks either have their content in-memory as persistent bytes,
+  or a _source_ which constructs new input streams for the block data on
+  demand. A block with in-memory content is considered a _loaded block_, while
+  blocks with other sources are _lazy blocks_.
 
-  A block's id, size, content, and reader cannot be changed after construction,
-  so clients can be relatively certain that the block's id is valid. Blocks
-  _may_ have additional attributes associated with them and support metadata,
-  similar to records."
+  A block's id, size, and content cannot be changed after construction, so
+  clients can be relatively certain that the block's id is valid. Blocks _may_
+  have additional attributes associated with them and support metadata, similar
+  to records."
   (:require
     [byte-streams :as bytes]
     [multihash.core :as multihash]
@@ -30,8 +30,7 @@
 (deftype Block
   [^Multihash id
    ^long size
-   ^PersistentBytes content
-   reader
+   content
    _attrs
    _meta]
 
@@ -43,7 +42,10 @@
   (toString
     [this]
     (format "Block[%s %s %s]"
-            id size (if content "*" (if reader "~" "!"))))
+            id size (cond
+                      (instance? PersistentBytes content) "*"
+                      content "~"
+                      :else "!")))
 
   (equals
     [this that]
@@ -76,7 +78,7 @@
 
   (withMeta
     [this meta-map]
-    (Block. id size content reader _attrs meta-map))
+    (Block. id size content _attrs meta-map))
 
 
   ; TODO: IKeywordLookup?
@@ -102,7 +104,7 @@
 
   (empty
     [this]
-    (Block. id size nil nil nil _meta))
+    (Block. id size nil nil _meta))
 
   (cons
     [this element]
@@ -148,18 +150,18 @@
   (assoc
     [this k v]
     (case k
-      (:id :size :content :reader)
+      (:id :size :content)
         (throw (IllegalArgumentException.
                  (str "Block " k " cannot be changed")))
-      (Block. id size content reader (assoc _attrs k v) _meta)))
+      (Block. id size content (assoc _attrs k v) _meta)))
 
   (without
     [this k]
     (case k
-      (:id :size :content :reader)
+      (:id :size :content)
         (throw (IllegalArgumentException.
                  (str "Block " k " cannot be changed")))
-      (Block. id size content reader (not-empty (dissoc _attrs k)) _meta))))
+      (Block. id size content (not-empty (dissoc _attrs k)) _meta))))
 
 
 (defmethod print-method Block
@@ -291,12 +293,12 @@
 
 
 (defn lazy-block
-  "Creates a block from a reader function. Each time the function is called, it
-  should return a new `InputStream` to read the block contents. The block is
-  given the id and size directly, without being checked."
+  "Creates a block from a content source. The simplest version is a no-arg
+  function which should return a new `InputStream` to read the block contents.
+  The block is given the id and size directly, without being checked."
   ^blocks.data.Block
   [id size reader]
-  (->Block id size nil reader nil nil))
+  (->Block id size reader nil nil))
 
 
 (defn load-block
@@ -306,17 +308,18 @@
   [id source]
   (let [content (collect-bytes source)]
     (when (pos? (count content))
-      (->Block id (count content) content nil nil nil))))
+      (->Block id (count content) content nil nil))))
 
 
 (defn read-block
   "Creates a block by reading the source into memory and hashing it."
   ^blocks.data.Block
   [algorithm source]
+  ; OPTIMIZE: calculate the hash while reading the content in one pass.
   (let [hash-fn (checked-hasher algorithm)
         content (collect-bytes source)]
     (when (pos? (count content))
-      (->Block (hash-fn (.open content)) (count content) content nil nil nil))))
+      (->Block (hash-fn (read-all content)) (count content) content nil nil))))
 
 
 (defn clean-block
@@ -325,16 +328,14 @@
   (->Block (.id block)
            (.size block)
            (.content block)
-           (.reader block)
            nil
            nil))
 
 
 (defn merge-blocks
   "Creates a new block by merging together two blocks representing the same
-  content. Block ids and sizes must match. The new block's content or reader
-  comes from the second block, and any extra attributes and metadata are merged
-  together."
+  content. Block ids and sizes must match. The new block's content comes from
+  the second block, and any extra attributes and metadata are merged together."
   [^Block a ^Block b]
   (when (not= (.id a) (.id b))
     (throw (IllegalArgumentException.
@@ -343,6 +344,5 @@
   (->Block (.id b)
            (.size b)
            (.content b)
-           (.reader b)
            (not-empty (merge (._attrs a) (._attrs b)))
            (not-empty (merge (._meta  a) (._meta  b)))))

--- a/src/blocks/data.clj
+++ b/src/blocks/data.clj
@@ -27,6 +27,12 @@
     org.apache.commons.io.input.BoundedInputStream))
 
 
+(defn persistent-bytes?
+  "True if the argument is a persistent byte array."
+  [x]
+  (instance? PersistentBytes x))
+
+
 (deftype Block
   [^Multihash id
    ^long size
@@ -43,7 +49,7 @@
     [this]
     (format "Block[%s %s %s]"
             id size (cond
-                      (instance? PersistentBytes content) "*"
+                      (persistent-bytes? content) "*"
                       content "~"
                       :else "!")))
 
@@ -235,12 +241,18 @@
 
 ;; ## Utility Functions
 
+(defn loaded?
+  "True if the block has content loaded into memory."
+  [^Block block]
+  (persistent-bytes? (.content block)))
+
+
 (defn- collect-bytes
   "Collects bytes from a data source into a `PersistentBytes` object. If the
   source is already persistent, it will be reused directly."
   ^PersistentBytes
   [source]
-  (if (instance? PersistentBytes source)
+  (if (persistent-bytes? source)
     source
     (PersistentBytes/wrap (bytes/to-byte-array source))))
 

--- a/src/blocks/store.clj
+++ b/src/blocks/store.clj
@@ -153,7 +153,7 @@
   keeping in-memory content. If none are, returns the first block."
   [& blocks]
   (when-let [blocks (seq (remove nil? blocks))]
-    (or (first (filter data/loaded? blocks))
+    (or (first (filter data/byte-content? blocks))
         (first blocks))))
 
 

--- a/src/blocks/store.clj
+++ b/src/blocks/store.clj
@@ -3,7 +3,7 @@
   API wrapper functions in `blocks.core` instead of using these methods
   directly."
   (:require
-    [blocks.data]
+    [blocks.data :as data]
     [clojure.string :as str]
     [multihash.core :as multihash])
   (:import
@@ -153,7 +153,7 @@
   keeping in-memory content. If none are, returns the first block."
   [& blocks]
   (when-let [blocks (seq (remove nil? blocks))]
-    (or (first (filter #(.content ^Block %) blocks))
+    (or (first (filter data/loaded? blocks))
         (first blocks))))
 
 

--- a/src/blocks/store/file.clj
+++ b/src/blocks/store/file.clj
@@ -132,6 +132,7 @@
   (block/with-stats
     (data/lazy-block
       id (.length file)
+      ; OPTIMIZE: return a ContentReader that can seek into the file.
       (fn file-reader [] (io/input-stream file)))
     (file-stats file)))
 

--- a/src/blocks/store/file.clj
+++ b/src/blocks/store/file.clj
@@ -30,7 +30,9 @@
     [clojure.tools.logging :as log]
     [multihash.core :as multihash])
   (:import
-    java.io.File
+    (java.io
+      File
+      FileInputStream)
     java.time.Instant))
 
 
@@ -132,8 +134,7 @@
   (block/with-stats
     (data/lazy-block
       id (.length file)
-      ; OPTIMIZE: return a ContentReader that can seek into the file.
-      (fn file-reader [] (io/input-stream file)))
+      (fn file-reader [] (FileInputStream. file)))
     (file-stats file)))
 
 

--- a/test/blocks/block_test.clj
+++ b/test/blocks/block_test.clj
@@ -54,8 +54,6 @@
           "size should not be settable")
       (is (thrown? IllegalArgumentException (assoc b2 :content nil))
           "content should not be settable")
-      (is (thrown? IllegalArgumentException (assoc b2 :reader nil))
-          "reader should not be settable")
       (is (thrown? IllegalArgumentException (dissoc b1 :id))
           "should not be dissociatable"))
     (testing "print-method"

--- a/test/blocks/block_test.clj
+++ b/test/blocks/block_test.clj
@@ -60,12 +60,11 @@
       (is (string? (pr-str b1))))))
 
 
-(deftest lazy-blocks
-  (let [original "foo bar baz abc123"
-        loaded (data/read-block :sha1 original)
-        lazy (data/lazy-block (:id loaded) (:size loaded)
-                              #(bytes/to-input-stream (.getBytes original)))]
-    (is (some? (.content loaded))
-        "loaded block should have content")
-    (is (nil? (.content lazy))
-        "lazy block should not have content")))
+(deftest block-laziness
+  (let [content "foo bar baz abc123"
+        loaded (data/read-block :sha1 content)
+        lazy (data/lazy-block
+               (:id loaded) (:size loaded)
+               #(bytes/to-input-stream (.getBytes content)))]
+    (is (data/loaded? loaded))
+    (is (not (data/loaded? lazy)))))

--- a/test/blocks/block_test.clj
+++ b/test/blocks/block_test.clj
@@ -66,5 +66,5 @@
         lazy (data/lazy-block
                (:id loaded) (:size loaded)
                #(bytes/to-input-stream (.getBytes content)))]
-    (is (data/loaded? loaded))
-    (is (not (data/loaded? lazy)))))
+    (is (data/byte-content? loaded))
+    (is (not (data/byte-content? lazy)))))

--- a/test/blocks/core_test.clj
+++ b/test/blocks/core_test.clj
@@ -77,7 +77,6 @@
               (Block. (if (= k :id)      v (:id b))
                       (if (= k :size)    v (:size b))
                       (if (= k :content) v (.content b))
-                      (if (= k :reader)  v (.reader b))
                       nil nil))]
     (testing "non-multihash id"
       (is (thrown? IllegalStateException

--- a/test/blocks/data_test.clj
+++ b/test/blocks/data_test.clj
@@ -40,8 +40,6 @@
             "should have b's size")
         (is (identical? (.content merged) (.content b))
             "should have b's content")
-        (is (nil? (.reader merged))
-            "should have no reader")
         (is (= true (:foo merged)))
         (is (= "baz" (:bar merged)))
         (is (= 'thing (:qux merged)))


### PR DESCRIPTION
This changes the internals of the `blocks.data.Block` type a bit to unify the idea of in-memory content (as `PersistentBytes`) and a lazy reader which can provide content streams on demand. In addition to simplifying logic in many places, this also gets rid of one warty part of the code where a ranged open on a lazy block would first try to call the reader function with two args, catch a `clojure.lang.ArityException` and fall back to the naive approach.

Most block store implementations outside this repo should continue to work; I've tested `blocks-s3` in particular since that's one of the most widely-used. Ranged opens will be less efficient until stores upgrade and start providing custom `ContentReader` implementations, since the new store code will no longer invoke the two-arg version of the reader function. 

Fixes #17 